### PR TITLE
Add event type chooser modal and merge homepage options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { Onboarding } from './components/OnboardingNew';
 import { Toaster } from './components/ui/sonner';
 import { InviteFloatingAction } from './components/InviteFloatingAction';
 import CreateActivityModal from './components/CreateActivityModal';
+import CreateEventChooserModal from './components/CreateEventChooserModal';
 import { toast } from 'sonner@2.0.3';
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isCreateEventModalOpen, setIsCreateEventModalOpen] = useState(false);
   const [isCreatePairingModalOpen, setIsCreatePairingModalOpen] = useState(false);
+  const [isCreateChooserOpen, setIsCreateChooserOpen] = useState(false);
 
   const handleOnboardingComplete = () => {
     setShowOnboarding(false);
@@ -27,7 +29,7 @@ export default function App() {
   };
 
   const handleCreateEvent = () => {
-    setIsCreateEventModalOpen(true);
+    setIsCreateChooserOpen(true);
   };
 
   const handleCreatePairing = () => {
@@ -44,7 +46,7 @@ export default function App() {
   const renderContent = () => {
     switch (activeTab) {
       case 'home':
-        return <Home onNavigate={setActiveTab} onCreatePairing={handleCreatePairing} />;
+        return <Home onNavigate={setActiveTab} onCreateEvent={handleCreateEvent} />;
       case 'search':
         return <Search />;
       case 'messages':
@@ -58,7 +60,7 @@ export default function App() {
       case 'notifications':
         return <Notifications onNavigate={setActiveTab} />;
       default:
-        return <Home onNavigate={setActiveTab} onCreatePairing={handleCreatePairing} />;
+        return <Home onNavigate={setActiveTab} onCreateEvent={handleCreateEvent} />;
     }
   };
 
@@ -83,6 +85,14 @@ export default function App() {
 
       {/* Invite Floating Action */}
       <InviteFloatingAction onNavigate={setActiveTab} onCreateEvent={handleCreateEvent} />
+
+      {/* Create Event Chooser */}
+      <CreateEventChooserModal
+        isOpen={isCreateChooserOpen}
+        onClose={() => setIsCreateChooserOpen(false)}
+        onChoosePairing={() => { setIsCreateChooserOpen(false); setIsCreatePairingModalOpen(true); }}
+        onChooseGroup={() => { setIsCreateChooserOpen(false); setIsCreateEventModalOpen(true); }}
+      />
 
       {/* Create Event Modal */}
       <CreateActivityModal

--- a/src/components/CreateActivityModal.tsx
+++ b/src/components/CreateActivityModal.tsx
@@ -285,7 +285,7 @@ export const CreateActivityModal: React.FC<CreateActivityModalProps> = ({
                 <div className="w-10 h-10 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 flex items-center justify-center">
                   <Zap className="w-5 h-5 text-white" />
                 </div>
-                <DialogTitle className="text-section-header font-semibold">Create Event</DialogTitle>
+                <DialogTitle className="text-section-header font-semibold">Create Group Activity</DialogTitle>
               </div>
               <Button
                 variant="ghost"
@@ -532,7 +532,7 @@ export const CreateActivityModal: React.FC<CreateActivityModalProps> = ({
               style={{ fontSize: '17px' }}
             >
               <Zap className="mr-2 w-5 h-5" />
-              Create Event
+              Create Activity
             </Button>
           </div>
         </div>

--- a/src/components/CreateEventChooserModal.tsx
+++ b/src/components/CreateEventChooserModal.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog';
+import { Button } from './ui/button';
+import { User, Users, ChevronRight } from 'lucide-react';
+
+interface CreateEventChooserModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onChoosePairing: () => void;
+  onChooseGroup: () => void;
+}
+
+const CreateEventChooserModal: React.FC<CreateEventChooserModalProps> = ({ isOpen, onClose, onChoosePairing, onChooseGroup }) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="glass-card border-0 max-w-lg max-h-[95vh] p-0">
+        <div className="flex flex-col h-full">
+          <DialogHeader className="px-6 py-4 bg-gradient-to-r from-purple-50 to-blue-50 border-b border-white/20">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 flex items-center justify-center">
+                  <Users className="w-5 h-5 text-white" />
+                </div>
+                <DialogTitle className="text-section-header font-semibold">What would you like to create?</DialogTitle>
+              </div>
+            </div>
+            <DialogDescription className="sr-only">Choose between creating a 1:1 pairing or a group activity.</DialogDescription>
+          </DialogHeader>
+
+          <div className="px-6 py-5 space-y-4">
+            <div className="text-subtext text-sm">Choose the option that fits your plan. You can always change your mind later.</div>
+
+            <button
+              className="w-full glass-card p-4 rounded-2xl hover:shadow-lg hover:bg-white/60 transition-all text-left"
+              onClick={onChoosePairing}
+            >
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-gradient-to-r from-blue-500 to-cyan-400 flex items-center justify-center">
+                  <User className="w-6 h-6 text-white" />
+                </div>
+                <div className="flex-1">
+                  <div className="text-body font-semibold">1:1 Pairing</div>
+                  <div className="text-subtext text-sm">Find a single partner matched by your preferences.</div>
+                </div>
+                <ChevronRight className="w-5 h-5 text-gray-400" />
+              </div>
+            </button>
+
+            <button
+              className="w-full glass-card p-4 rounded-2xl hover:shadow-lg hover:bg-white/60 transition-all text-left"
+              onClick={onChooseGroup}
+            >
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-gradient-to-r from-green-500 to-emerald-400 flex items-center justify-center">
+                  <Users className="w-6 h-6 text-white" />
+                </div>
+                <div className="flex-1">
+                  <div className="text-body font-semibold">Group Activity</div>
+                  <div className="text-subtext text-sm">Host an event for multiple people to join.</div>
+                </div>
+                <ChevronRight className="w-5 h-5 text-gray-400" />
+              </div>
+            </button>
+          </div>
+
+          <div className="px-6 pb-5">
+            <Button onClick={onClose} variant="outline" className="w-full rounded-full">Cancel</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateEventChooserModal;

--- a/src/components/CreateEventPrompt.tsx
+++ b/src/components/CreateEventPrompt.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button } from './ui/button';
+import { User, Users, Plus } from 'lucide-react';
+
+interface CreateEventPromptProps {
+  onClick: () => void;
+}
+
+const CreateEventPrompt: React.FC<CreateEventPromptProps> = ({ onClick }) => {
+  return (
+    <div className="glass-card p-6 bg-gradient-to-r from-blue-50/50 to-cyan-50/50 relative overflow-hidden">
+      <div className="absolute top-0 right-0 w-24 h-24 bg-gradient-to-br from-blue-200/30 to-cyan-200/30 rounded-full -translate-y-6 translate-x-6"></div>
+      <div className="absolute bottom-0 left-0 w-16 h-16 bg-gradient-to-tr from-purple-200/30 to-pink-200/30 rounded-full translate-y-4 -translate-x-4"></div>
+
+      <div className="text-center space-y-4 relative z-10">
+        <div className="w-16 h-16 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full flex items-center justify-center mx-auto shadow-lg">
+          <Plus className="h-8 w-8 text-white" />
+        </div>
+
+        <div>
+          <h3 className="text-section-header gradient-text mb-2">Start Something New</h3>
+          <p className="text-subtext">Create a 1:1 pairing or plan a group activity—whatever fits your plan.</p>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-2 py-2">
+          <div className="flex items-center space-x-1 bg-white/60 rounded-full px-3 py-1">
+            <User className="h-3 w-3 text-blue-500" />
+            <span className="text-xs text-gray-600">1:1 Pairing</span>
+          </div>
+          <div className="flex items-center space-x-1 bg-white/60 rounded-full px-3 py-1">
+            <Users className="h-3 w-3 text-green-500" />
+            <span className="text-xs text-gray-600">Group Activity</span>
+          </div>
+        </div>
+
+        <Button 
+          className="bg-gradient-to-r from-blue-500 to-cyan-400 text-white rounded-full px-8 py-3 text-button shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200"
+          onClick={onClick}
+        >
+          <Plus className="mr-2 w-5 h-5" />
+          Create New
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CreateEventPrompt;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -7,7 +7,6 @@ import { ImageWithFallback } from './figma/ImageWithFallback';
 import NearbyActivitiesBlock from './NearbyActivitiesBlock';
 import CreateEventPrompt from './CreateEventPrompt';
 import EventSummaryCard from './EventSummaryCard';
-import { toast } from 'sonner@2.0.3';
 
 // Mock data
 const upcomingActivities = [

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -5,10 +5,8 @@ import { Badge } from './ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { ImageWithFallback } from './figma/ImageWithFallback';
 import NearbyActivitiesBlock from './NearbyActivitiesBlock';
-import CreateActivityPrompt from './CreateActivityPrompt';
-import CreatePairingPrompt from './CreatePairingPrompt';
+import CreateEventPrompt from './CreateEventPrompt';
 import EventSummaryCard from './EventSummaryCard';
-import CreateActivityModal from './CreateActivityModal';
 import { toast } from 'sonner@2.0.3';
 
 // Mock data
@@ -65,14 +63,13 @@ const mockEvents = [
 
 interface HomeProps {
   onNavigate?: (tab: string) => void;
-  onCreatePairing?: () => void;
+  onCreateEvent?: () => void;
 }
 
-export function Home({ onNavigate, onCreatePairing }: HomeProps = { onNavigate: () => {} }) {
+export function Home({ onNavigate, onCreateEvent }: HomeProps = { onNavigate: () => {} }) {
   const [userLevel] = useState(8);
   const [userXP] = useState(1250);
   const [nextLevelXP] = useState(1500);
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   const handleViewAllEvents = () => {
     onNavigate?.('calendar');
@@ -82,16 +79,7 @@ export function Home({ onNavigate, onCreatePairing }: HomeProps = { onNavigate: 
     onNavigate?.('calendar');
   };
 
-  const handleCreateActivity = () => {
-    setIsCreateModalOpen(true);
-  };
 
-  const handleCreateActivityModal = (activityData: any) => {
-    toast.success('Activity created successfully!', {
-      description: `${activityData.title} has been scheduled for ${activityData.date}`,
-    });
-    console.log('Created activity:', activityData);
-  };
 
   return (
     <div className="h-full bg-gradient-to-br from-slate-50 to-gray-100 overflow-y-auto">
@@ -196,26 +184,15 @@ export function Home({ onNavigate, onCreatePairing }: HomeProps = { onNavigate: 
           <NearbyActivitiesBlock />
         </div>
 
-        {/* Create Pairing Prompt */}
+        {/* Create Event Prompt */}
         <div>
-          <CreatePairingPrompt onClick={() => onCreatePairing?.()} />
-        </div>
-
-        {/* Create Activity Prompt */}
-        <div>
-          <CreateActivityPrompt onClick={handleCreateActivity} />
+          <CreateEventPrompt onClick={() => onCreateEvent?.()} />
         </div>
 
         {/* Bottom padding for navigation */}
         <div className="h-20"></div>
       </div>
 
-      {/* Create Activity Modal */}
-      <CreateActivityModal
-        isOpen={isCreateModalOpen}
-        onClose={() => setIsCreateModalOpen(false)}
-        onCreateActivity={handleCreateActivityModal}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Purpose

The user wanted to simplify the event creation flow by:
- Adding a single entry point with two options: 1:1 pairing modal and group modal within create event
- Merging the homepage options to eliminate the separate "Find a Perfect 1:1 Partner" and "Ready to Create Something Amazing?" sections
- Improving user experience with clearer naming and subtexts for better understanding

## Code changes

- **Added new `CreateEventChooserModal` component** that presents users with two clear options:
  - 1:1 Pairing: "Find a single partner matched by your preferences"
  - Group Activity: "Host an event for multiple people to join"
- **Updated App.tsx** to integrate the chooser modal into the flow:
  - Added state management for the chooser modal
  - Modified event creation handler to open chooser instead of direct modal
  - Updated Home component props to use unified `onCreateEvent` handler
- **Replaced separate homepage prompts** with unified `CreateEventPrompt` component:
  - Removed `CreateActivityPrompt` and `CreatePairingPrompt` components
  - New component shows both options as badges with clear visual distinction
- **Updated modal titles** for consistency:
  - "Create Event" → "Create Group Activity"
  - Button text updated to "Create Activity"
- **Streamlined Home component** by removing duplicate modal logic and handlersTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f4ba8fba59b04e718872cc601cbcf0f5/mystic-home)

👀 [Preview Link](https://f4ba8fba59b04e718872cc601cbcf0f5-mystic-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f4ba8fba59b04e718872cc601cbcf0f5</projectId>-->
<!--<branchName>mystic-home</branchName>-->